### PR TITLE
feat: delete "users" collection in firestore

### DIFF
--- a/public/components/home.js
+++ b/public/components/home.js
@@ -80,6 +80,7 @@ $root.addEventListener('click', async e => {
   const targetId = e.target.closest('.card').id;
 
   db.collection('votes').doc(targetId).delete();
+  db.collection('users').doc(loginedEmail).collection('voteList').doc(targetId).delete();
 
   render();
 });


### PR DESCRIPTION
- 투표 삭제 시 "users"컬렉션에서 해당 투표 id가 삭제되도록 했습니다.

clsoe #[26](https://github.com/galPang-JilPang/Eat-It/issues/26)